### PR TITLE
[codex] Bump thisplot version to 0.3.9

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: thisplot
 Title: Utility Functions for Plotting
-Version: 0.3.8
+Version: 0.3.9
 Date: 2026-04-23
 Authors@R:
     c(


### PR DESCRIPTION
## Summary
- bump package version to `0.3.9`
- mark the merged `trend_alluvial` StatPlot support as a dependency-resolvable version

## Why
`scop` now exposes `plot_type = "trend_alluvial"`, which requires the merged `thisplot::StatPlot()` implementation. Without a version bump, an installed `thisplot 0.3.8` can satisfy dependency constraints while missing the new plot type.

## Validation
- parsed DESCRIPTION with R and confirmed `Version: 0.3.9`
