### PR TITLE
Refine trend alluvial StatPlot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: thisplot
 Title: Utility Functions for Plotting
-Version: 0.3.8
+Version: 0.3.9
 Date: 2026-04-23
 Authors@R:
     c(

--- a/R/StatPlot.R
+++ b/R/StatPlot.R
@@ -700,33 +700,26 @@ StatPlot <- function(
             dat,
             aes(
               x = .data[[g]],
-              y = value
+              y = value,
+              fill = .data[[stat.by]],
+              stratum = .data[[stat.by]],
+              alluvium = .data[[stat.by]]
             )
           ) +
             bg_layer +
             geom_col(
-              aes(fill = .data[[stat.by]]),
               width = 0.6,
               color = NA,
               alpha = alpha,
               position = position_use
             ) +
             ggalluvial::geom_flow(
-              aes(
-                fill = .data[[stat.by]],
-                stratum = .data[[stat.by]],
-                alluvium = .data[[stat.by]]
-              ),
               width = 0.6,
               alpha = alpha * 0.22,
               knot.pos = 0.35,
               color = "white"
             ) +
             ggalluvial::geom_alluvium(
-              aes(
-                stratum = .data[[stat.by]],
-                alluvium = .data[[stat.by]]
-              ),
               width = 0.6,
               alpha = alpha,
               knot.pos = 0.35,


### PR DESCRIPTION
## Summary
- bump thisplot to 0.3.9 for the trend_alluvial StatPlot change
- keep trend_alluvial in the existing trend-style plotting path
- move the alluvial aesthetics onto the base ggplot mapping so geom_col, geom_flow, and geom_alluvium share the same x/y/fill/stat mapping

## Validation
- locally installed thisutils 0.4.5 and thisplot 0.3.9
- ran StatPlot(..., plot_type = 'trend_alluvial') for stat_type = 'percent' and 'count'
- verified percent y range is 0,1 and count height uses raw counts
- ran tools::checkRd on StatPlot.Rd
<img width="637" height="663" alt="image" src="https://github.com/user-attachments/assets/1a0e496e-9160-44bb-a7af-d75f81124314" />
